### PR TITLE
Add support for sending notifications to Discord webhook

### DIFF
--- a/src/CgLogListener.sln
+++ b/src/CgLogListener.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LineNotifier", "LineNotifie
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TelegramNotifier", "TelegramNotifier\TelegramNotifier.csproj", "{C4491C6F-82CE-4D33-B1CC-8C4F16984E97}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DiscordNotifier", "DiscordNotifier\DiscordNotifier.csproj", "{7F0CAD47-7583-479B-8BD2-7901CD5B81CB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{C4491C6F-82CE-4D33-B1CC-8C4F16984E97}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C4491C6F-82CE-4D33-B1CC-8C4F16984E97}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C4491C6F-82CE-4D33-B1CC-8C4F16984E97}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F0CAD47-7583-479B-8BD2-7901CD5B81CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F0CAD47-7583-479B-8BD2-7901CD5B81CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F0CAD47-7583-479B-8BD2-7901CD5B81CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F0CAD47-7583-479B-8BD2-7901CD5B81CB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/DiscordNotifier/App.config
+++ b/src/DiscordNotifier/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+    </startup>
+</configuration>

--- a/src/DiscordNotifier/DiscordNotifier.csproj
+++ b/src/DiscordNotifier/DiscordNotifier.csproj
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+    <PropertyGroup>
+        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+        <ProjectGuid>{7F0CAD47-7583-479B-8BD2-7901CD5B81CB}</ProjectGuid>
+        <OutputType>Exe</OutputType>
+        <RootNamespace>DiscordNotifier</RootNamespace>
+        <AssemblyName>DiscordNotifier</AssemblyName>
+        <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+        <FileAlignment>512</FileAlignment>
+        <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+        <Deterministic>true</Deterministic>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <DebugSymbols>true</DebugSymbols>
+        <DebugType>full</DebugType>
+        <Optimize>false</Optimize>
+        <OutputPath>bin\Debug\</OutputPath>
+        <DefineConstants>DEBUG;TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <DebugType>pdbonly</DebugType>
+        <Optimize>true</Optimize>
+        <OutputPath>bin\Release\</OutputPath>
+        <DefineConstants>TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+    <ItemGroup>
+        <Reference Include="INIFileParser, Version=2.5.2.0, Culture=neutral, PublicKeyToken=79af7b307b65cf3c, processorArchitecture=MSIL">
+          <HintPath>..\packages\ini-parser.2.5.2\lib\net20\INIFileParser.dll</HintPath>
+        </Reference>
+        <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+          <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+        </Reference>
+        <Reference Include="System" />
+        <Reference Include="System.Core" />
+        <Reference Include="System.Xml.Linq" />
+        <Reference Include="System.Data.DataSetExtensions" />
+        <Reference Include="Microsoft.CSharp" />
+        <Reference Include="System.Data" />
+        <Reference Include="System.Net.Http" />
+        <Reference Include="System.Xml" />
+    </ItemGroup>
+    <ItemGroup>
+        <Compile Include="DiscordNotifyHelper.cs" />
+        <Compile Include="Program.cs" />
+    </ItemGroup>
+    <ItemGroup>
+        <None Include="App.config" />
+        <None Include="DiscordNotifier.ini" />
+        <None Include="packages.config" />
+    </ItemGroup>
+    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/DiscordNotifier/DiscordNotifier.ini
+++ b/src/DiscordNotifier/DiscordNotifier.ini
@@ -1,0 +1,1 @@
+webhookUrl=

--- a/src/DiscordNotifier/DiscordNotifyHelper.cs
+++ b/src/DiscordNotifier/DiscordNotifyHelper.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace DiscordNotifier
+{
+    public static class DiscordNotifyHelper
+    {
+        public static async Task Notify(string webhookUrl, string message)
+        {
+            try
+            {
+                var payload = new
+                {
+                    content = message,
+                    username = "CgLogListener",
+                };
+                
+                var httpClient = new HttpClient();
+
+                var json = JsonConvert.SerializeObject(payload);
+                var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+                var response = await httpClient.PostAsync(webhookUrl, content);
+                response.EnsureSuccessStatusCode();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Discord通知送信エラー: {ex.Message}");
+            }
+        }
+    }
+}

--- a/src/DiscordNotifier/Program.cs
+++ b/src/DiscordNotifier/Program.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IO;
+using IniParser;
+
+namespace DiscordNotifier
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            const string iniFilename = "DiscordNotifier.ini";
+
+            if (!File.Exists(iniFilename))
+            {
+                return;
+            }
+
+            try
+            {
+                var ini = new FileIniDataParser().ReadFile(iniFilename);
+                if (ini.TryGetKey("webhookUrl", out var webhookUrl) && !string.IsNullOrEmpty(webhookUrl))
+                {
+                    DiscordNotifyHelper.Notify(webhookUrl, args[0]).Wait();
+                }
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+    }
+}

--- a/src/DiscordNotifier/packages.config
+++ b/src/DiscordNotifier/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net46" />
+  <package id="ini-parser" version="2.5.2" targetFramework="net46" />
+</packages>


### PR DESCRIPTION
Since the Line Notify service was discontinued on March 31, I extended the functionality to support sending notifications to Discord webhooks. I believe there is already a package for Telegram, but many Japanese players specifically requested Discord support. If you’re interested, please take a look!

![スクリーンショット 2025-04-02 023151](https://github.com/user-attachments/assets/0d02f38d-8be2-4191-8772-056c244fe846)

